### PR TITLE
Deregister the default front-end script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ If the toggle is off, no JavaScript is loaded on the front end.
 
 ## Changelog
 
+### 2.0.3
+
+* Fix an issue where the front-end script was enqueued twice.
+
 ### 2.0.2
 
 * Fix an issue preventing Open All toggle from working in Chrome.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "show-hide-section",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "show-hide-section",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@wordpress/scripts": "^26.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "show-hide-section",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Display an accessible show/hide interface with details and summary elements.",
   "author": "Happy Prime",
   "license": "GPL-2.0-or-later",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Show / Hide Section Block
  * Description: Display an accessible show/hide interface with details and summary elements.
- * Version: 2.0.2
+ * Version: 2.0.3
  * Plugin URI: https://wordpress.org/plugins/show-hide-section-block/
  * Author: Happy Prime
  * Author URI: https://happyprime.co/

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: happyprime, jeremyfelt, slocker, philcable
 Tags: collapsible, details, summary
 Requires at least: 6.1
 Tested up to: 6.2
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv2 or later
 Requires PHP: 7.4
 
@@ -41,6 +41,10 @@ An option is provided in the block's side panel to toggle an "Open all"/"Close a
 If the toggle is off, no JavaScript is loaded on the front end.
 
 ## Changelog
+
+### 2.0.3
+
+* Fix an issue where the front-end script was enqueued twice.
 
 ### 2.0.2
 

--- a/src/show-hide-group/index.php
+++ b/src/show-hide-group/index.php
@@ -8,7 +8,7 @@
 namespace HappyPrime\Blocks\ShowHideGroup;
 
 add_action( 'init', __NAMESPACE__ . '\register' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\dequeue_default', 11 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\deregister_default', 11 );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_assets', 2 );
 add_filter( 'pre_render_block', __NAMESPACE__ . '\maybe_enqueue_script', 10, 2 );
 
@@ -20,10 +20,10 @@ function register() {
 }
 
 /**
- * Dequeue the default script handle added via WordPress via block.json.
+ * Deregister the default script handle added via WordPress via block.json.
  */
-function dequeue_default() {
-	wp_dequeue_script( 'happyprime-show-hide-group-view-script' );
+function deregister_default() {
+	wp_deregister_script( 'happyprime-show-hide-group-view-script' );
 }
 
 /**


### PR DESCRIPTION
Dequeuing is not enough: classic themes will re-enqueue it after `wp_enqueue_scripts`. 🕺