### PR TITLE
Fix script handle mismatch for hash navigation

### DIFF
--- a/src/show-hide-group/index.php
+++ b/src/show-hide-group/index.php
@@ -71,7 +71,7 @@ function maybe_enqueue_script( $pre_render, array $parsed_block ) {
 		// If a section has an ID attribute, enqueue the script to support
 		// improved hash navigation.
 		if ( $inner_html->next_tag( [ 'id' => true ] ) ) {
-			wp_enqueue_script( 'happyprime-show-hide-section-view' );
+			wp_enqueue_script( 'happyprime-show-hide-group-view' );
 			$enqueued = true;
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes script handle mismatch that prevented hash navigation from working

## Problem
The `maybe_enqueue_script()` function was trying to enqueue a non-existent script handle `happyprime-show-hide-section-view` when a section block had an ID attribute. This caused the hash navigation feature to fail silently.

## Solution
Changed line 74 to use the correct registered handle `happyprime-show-hide-group-view`.

## Test Plan
- [ ] Add a Show/Hide Section block with an anchor/ID
- [ ] Navigate to the page with a hash in the URL (e.g., `#section-id`)
- [ ] Verify the section opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)