### PR TITLE
Fix invalid HTML nesting in summary block

### DIFF
--- a/src/show-hide-summary/index.js
+++ b/src/show-hide-summary/index.js
@@ -34,7 +34,7 @@ const Save = (props) => {
 
 	return (
 		<summary {...useBlockProps.save()}>
-			<RichText.Content tag={'summary'} value={summary} />
+			<RichText.Content tagName="div" value={summary} />
 		</summary>
 	);
 };


### PR DESCRIPTION
## Summary
- Fixes invalid nested `<summary>` tags in the summary block output

## Problem
The Save component was rendering `<summary><summary>...</summary></summary>` which is invalid HTML. This causes:
- HTML validation errors
- Potential accessibility issues
- Unpredictable browser rendering

## Solution
Changed `RichText.Content` from `tag={'summary'}` to `tagName="div"` on line 37. This outputs valid HTML: `<summary><div>...</div></summary>`.

## Test Plan
- [ ] Create a Show/Hide Section block
- [ ] Add summary text
- [ ] View frontend HTML and verify no nested `<summary>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)