### PR TITLE
Add i18n support for frontend toggle button text

### DIFF
--- a/src/show-hide-group/index.php
+++ b/src/show-hide-group/index.php
@@ -43,6 +43,11 @@ function register_assets() {
 		$asset_data['version'],
 		true
 	);
+
+	wp_set_script_translations(
+		'happyprime-show-hide-group-view',
+		'show-hide-section-block'
+	);
 }
 
 /**

--- a/src/show-hide-group/view.js
+++ b/src/show-hide-group/view.js
@@ -1,4 +1,6 @@
 {
+	const { __ } = wp.i18n;
+
 	const handleToggleButton = () => {
 		const toggleAll = document.querySelectorAll(
 			'.wp-block-happyprime-show-hide-group .toggle-all'
@@ -16,14 +18,14 @@
 							detail.setAttribute('open', 'true');
 						});
 
-						toggle.innerText = 'Close All';
+						toggle.innerText = __('Close all', 'show-hide-section-block');
 						toggle.ariaExpanded = 'true';
 					} else {
 						details.forEach((detail) => {
 							detail.removeAttribute('open');
 						});
 
-						toggle.innerText = 'Open All';
+						toggle.innerText = __('Open all', 'show-hide-section-block');
 						toggle.ariaExpanded = 'false';
 					}
 				})


### PR DESCRIPTION
## Summary
- Adds internationalization support for frontend toggle button text

## Problem
The toggle button text ('Open All' and 'Close All') was hardcoded in English in the frontend JavaScript (view.js lines 19, 26), preventing translation into other languages.

## Solution
- Added `wp_set_script_translations()` call in `register_assets()` function
- Imported `wp.i18n.__()` in view.js
- Wrapped hardcoded strings with `__()` translation function
- Changed 'Close All' to 'Close all' to match editor string casing

## Test Plan
- [ ] Build the plugin with `npm run build`
- [ ] Create a Show/Hide Group block with toggle enabled
- [ ] Verify toggle button text is translatable
- [ ] Switch WordPress language and verify translations load

🤖 Generated with [Claude Code](https://claude.com/claude-code)