### PR TITLE
Remove unused variables and invalid attribute from template

### DIFF
--- a/src/show-hide-section/index.js
+++ b/src/show-hide-section/index.js
@@ -6,23 +6,14 @@ import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import deprecated from './deprecated';
 
-const Edit = (props) => {
-	const {
-		attributes: { isOpen },
-		setAttributes,
-		isSelected,
-	} = props;
-
+const Edit = () => {
 	// Create an inner blocks template for the content.
 	const TEMPLATE = [
 		[
 			'happyprime/show-hide-summary',
 			{ summary: __('Summary', 'show-hide-section-block') },
 		],
-		[
-			'happyprime/show-hide-details',
-			{ details: __('Details', 'show-hide-section-block') },
-		],
+		['happyprime/show-hide-details'],
 	];
 
 	return (


### PR DESCRIPTION
## Summary
- Removes unused destructured variables from Edit component
- Removes invalid attribute from template definition

## Problem
The Edit component in show-hide-section/index.js had several unused variables:
- `isOpen` (line 11)
- `setAttributes` (line 12)
- `isSelected` (line 13)

Additionally, the template was passing an invalid `details` attribute to the show-hide-details block (line 24), which doesn't exist in that block's schema.

## Solution
- Removed unused destructured variables
- Simplified Edit component signature to remove unused `props` parameter
- Removed invalid `details` attribute from template array

## Test Plan
- [ ] Build the plugin with `npm run build`
- [ ] Create a Show/Hide Section block
- [ ] Verify it still functions correctly
- [ ] Check browser console for any errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)