### PR TITLE
Add consistent return type declarations to all functions

### DIFF
--- a/src/show-hide-details/index.php
+++ b/src/show-hide-details/index.php
@@ -12,6 +12,6 @@ add_action( 'init', __NAMESPACE__ . '\register' );
 /**
  * Register the block.
  */
-function register() {
+function register(): void {
 	register_block_type_from_metadata( HP_SHS_PLUGIN_DIR . '/build/show-hide-details' );
 }

--- a/src/show-hide-group/index.php
+++ b/src/show-hide-group/index.php
@@ -15,7 +15,7 @@ add_filter( 'pre_render_block', __NAMESPACE__ . '\maybe_enqueue_script', 10, 2 )
 /**
  * Register the block.
  */
-function register() {
+function register(): void {
 	register_block_type_from_metadata( HP_SHS_PLUGIN_DIR . '/build/show-hide-group' );
 }
 
@@ -29,7 +29,7 @@ function deregister_default(): void {
 /**
  * Make front-end scripting available for enqueue if the block is in use.
  */
-function register_assets() {
+function register_assets(): void {
 	if ( ! has_block( 'happyprime/show-hide-group' ) || is_admin() ) {
 		return;
 	}

--- a/src/show-hide-section/index.php
+++ b/src/show-hide-section/index.php
@@ -12,6 +12,6 @@ add_action( 'init', __NAMESPACE__ . '\register' );
 /**
  * Register the block.
  */
-function register() {
+function register(): void {
 	register_block_type_from_metadata( HP_SHS_PLUGIN_DIR . '/build/show-hide-section' );
 }

--- a/src/show-hide-summary/index.php
+++ b/src/show-hide-summary/index.php
@@ -12,6 +12,6 @@ add_action( 'init', __NAMESPACE__ . '\register' );
 /**
  * Register the block.
  */
-function register() {
+function register(): void {
 	register_block_type_from_metadata( HP_SHS_PLUGIN_DIR . '/build/show-hide-summary' );
 }


### PR DESCRIPTION
## Summary
- Adds void return type declarations consistently across all PHP functions

## Problem
Only `deregister_default()` had a return type declaration (`: void`). All other functions lacked return type declarations, creating inconsistency in the codebase.

For a PHP 7.4+ plugin, return type declarations improve:
- Type safety
- Code documentation
- IDE autocomplete/hints
- Consistency with modern PHP standards

## Solution
Added `: void` return type declarations to:
- `register()` in show-hide-section/index.php
- `register()` in show-hide-details/index.php
- `register()` in show-hide-summary/index.php
- `register()` in show-hide-group/index.php
- `register_assets()` in show-hide-group/index.php

## Test Plan
- [ ] Run `composer phpcs` to verify coding standards pass
- [ ] Test plugin activation/deactivation
- [ ] Create blocks and verify no PHP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)