### PR TITLE
Remove unnecessary fragment wrapper in Edit component

### DIFF
--- a/src/show-hide-details/index.js
+++ b/src/show-hide-details/index.js
@@ -13,11 +13,7 @@ const Edit = () => {
 		],
 	];
 
-	return (
-		<>
-			<InnerBlocks template={TEMPLATE} templateLock={false} />
-		</>
-	);
+	return <InnerBlocks template={TEMPLATE} templateLock={false} />;
 };
 
 const Save = () => {


### PR DESCRIPTION
## Summary
- Removes unnecessary React fragment wrapper from show-hide-details Edit component

## Problem
The Edit component in show-hide-details/index.js wrapped the `InnerBlocks` component in a React fragment (lines 17-19):

```jsx
return (
  <>
    <InnerBlocks template={TEMPLATE} templateLock={false} />
  </>
);
```

React fragments are only needed when returning multiple sibling elements. Since this component returns a single element, the fragment is unnecessary and adds visual clutter.

## Solution
Simplified the return statement to directly return the `InnerBlocks` component:

```jsx
return <InnerBlocks template={TEMPLATE} templateLock={false} />;
```

## Test Plan
- [ ] Build the plugin with `npm run build`
- [ ] Create a Show/Hide Details block
- [ ] Verify it renders and functions correctly
- [ ] Check for any console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)