### PR TITLE
Add JSDoc documentation to handleToggleButton function

### DIFF
--- a/src/show-hide-group/view.js
+++ b/src/show-hide-group/view.js
@@ -1,4 +1,12 @@
 {
+	/**
+	 * Attach click event handlers to toggle all buttons.
+	 *
+	 * Finds all toggle buttons in show-hide-group blocks and adds click handlers
+	 * that open or close all detail elements within the group.
+	 *
+	 * @returns {void}
+	 */
 	const handleToggleButton = () => {
 		const toggleAll = document.querySelectorAll(
 			'.wp-block-happyprime-show-hide-group .toggle-all'


### PR DESCRIPTION
## Summary
- Adds JSDoc documentation to the `handleToggleButton()` function

## Problem
Only the `handleHashNavigation()` function had JSDoc documentation in view.js. The `handleToggleButton()` function lacked documentation, creating inconsistency and making it harder for developers to understand the code.

## Solution
Added a comprehensive JSDoc comment to `handleToggleButton()` that:
- Describes the function's purpose
- Explains what it does (finds toggle buttons and attaches click handlers)
- Documents the return type (`@returns {void}`)

This brings documentation consistency across the file and improves IDE autocomplete/intellisense support.

## Test Plan
- [ ] Review the code documentation
- [ ] Verify JSDoc formatting is correct
- [ ] Check IDE autocomplete suggestions for the function

🤖 Generated with [Claude Code](https://claude.com/claude-code)