### PR TITLE
Add comments explaining action hook priority numbers

### DIFF
--- a/src/show-hide-group/index.php
+++ b/src/show-hide-group/index.php
@@ -8,7 +8,9 @@
 namespace HappyPrime\Blocks\ShowHideGroup;
 
 add_action( 'init', __NAMESPACE__ . '\register' );
+// Priority 11 to run after WordPress enqueues the default script (priority 10).
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\deregister_default', 11 );
+// Priority 2 to register early in the enqueue_block_assets sequence.
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_assets', 2 );
 add_filter( 'pre_render_block', __NAMESPACE__ . '\maybe_enqueue_script', 10, 2 );
 


### PR DESCRIPTION
## Summary
- Adds inline comments explaining why specific hook priorities are used

## Problem
The action hooks used non-default priority numbers (11 and 2) without explanation:
- Line 11: `add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\deregister_default', 11 )`
- Line 12: `add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_assets', 2 )`

Without comments, it's unclear why these specific priorities were chosen, making the code harder to maintain.

## Solution
Added inline comments explaining:
- **Priority 11**: Runs after WordPress enqueues the default script (priority 10), allowing us to deregister it
- **Priority 2**: Registers early in the enqueue_block_assets sequence for optimal timing

## Test Plan
- [ ] Review the code comments for clarity
- [ ] Verify the comments accurately describe the behavior
- [ ] No functional changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)